### PR TITLE
active tags now highlighted via bg & text color

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -20,6 +20,9 @@
   .tag-color {
     @apply bg-light-grayish-cyan-background text-desaturated-dark-cyan;
   }
+  .active-tag-color {
+    @apply bg-desaturated-dark-cyan text-white
+  }
 }
 
 .App {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,6 +61,9 @@ function App() {
     }
   };
 
+  const activeJobListings =
+    filterListings.length > 0 ? filterListings : jobData;
+
   return (
     <div className="App">
       <header>
@@ -93,11 +96,11 @@ function App() {
       </div>
       <section className="py-12 main-content md:pt-14 w-[327px] m-auto md:m-w-[90%] md:w-3/4">
         <section className="job-listings flex flex-col gap-10 md:gap-4">
-          {filterListings.length > 0 ? (
-            <JobListing jobsData={filterListings} addFilter={handleAddFilter} />
-          ) : (
-            <JobListing jobsData={jobData} addFilter={handleAddFilter} />
-          )}
+          <JobListing
+            jobsData={activeJobListings}
+            addFilter={handleAddFilter}
+            filters={searchFilters}
+          />
         </section>
       </section>
     </div>

--- a/src/components/JobListing/JobListing.tsx
+++ b/src/components/JobListing/JobListing.tsx
@@ -5,9 +5,10 @@ import { JobListingObj } from '../../types/JobListingObj';
 interface Props {
   jobsData: JobListingObj[];
   addFilter: (term: string) => void;
+  filters: string[];
 }
 
-export function JobListing({ jobsData, addFilter }: Props) {
+export function JobListing({ jobsData, addFilter, filters }: Props) {
   const jobListingsMarkup = jobsData.map((job, index) => {
     const tags = [job.role, job.level, ...job.languages, ...job.tools];
 
@@ -49,7 +50,7 @@ export function JobListing({ jobsData, addFilter }: Props) {
           </div>
         </div>
         <hr className="my-2" />
-        <Tags tags={tags} addFilter={addFilter} />
+        <Tags tags={tags} addFilter={addFilter} filters={filters}/>
       </article>
     );
   });

--- a/src/components/JobListing/components/Tags.tsx
+++ b/src/components/JobListing/components/Tags.tsx
@@ -3,18 +3,24 @@ import React from 'react';
 interface Props {
   tags: string[];
   addFilter: (term: string) => void;
+  filters: string[];
 }
 
-export function Tags({ tags, addFilter }: Props) {
-  const tagMarkup = tags.map((tag, index) => (
+export function Tags({ tags, addFilter,filters }: Props) {
+  const tagMarkup = tags.map((tag, index) => {
+  const isActiveTag = filters.includes(tag)
+
+  return (
     <div
       key={tag}
-      className="flex items-center leading-none py-2 pb-1 px-3 bg-light-grayish-cyan-background text-desaturated-dark-cyan rounded-t-md rounded-b-md font-bold hover:bg-desaturated-dark-cyan hover:text-white hover:cursor-pointer"
+      className={`flex-center tag-color leading-none py-2 pb-1 px-3 rounded-t-md rounded-b-md font-bold
+      ${isActiveTag ? 'active-tag-color' : 'hover:bg-desaturated-dark-cyan hover:text-white hover:cursor-pointer'}`}
       onClick={() => addFilter(tag)}
     >
       {tag}
     </div>
-  ));
+  )
+});
 
   return (
     <div className="flex flex-wrap gap-[15px] grow bg-white pt-4 md:px-4 md:justify-end">


### PR DESCRIPTION
### What is this PR solving?

Add a new feature that highlights any tags, via changing background/text color, that have been added to the search filter.

### Screenshots/Video
<img src="https://i.imgur.com/upYKJc8.png" />

### Focus for reviewers
Confirm the tags change bg/text color

### Testing instructions
[Deploy Preview Link](https://deploy-preview-2--fe-mentor-job-listings.netlify.app/)

- Click on a tag to add it as a serch filter and confirm that it's bg and text color change
- Remove the tag from the search filter and confirm that it's bg and text go back to normal
- Click the **Clear** button to clear all the filters and confirm that it's bg and text go back to normal

<hr> 

- [x] I tested and confirmed the changes
- [x] This PR is safe to rollback.
<!-- If it is not safe, please detail what would need to happen to make it safe. For example, if this PR removes a GraphQL field that will then be removed from the schema, link to the Shopify Core PR that removes the field. -->
- [x] Added the correct label
- [x] This PR follows the recommendations regarding squashig commits